### PR TITLE
Bump dependencies (mio & nix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 mio = "0.6"
-nix = "0.13.0"
+nix = "0.24.1"
 libc = "0.2"
 enum_primitive = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-mio = "0.6"
+mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 nix = "0.24.1"
 libc = "0.2"
 enum_primitive = "0.1"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ BtSocket::connect_async()
 BtSocket::read()
 BtSocket::write()
 
-impl mio::Evented for BtSocket { ... } // for async IO with mio
+impl mio::event::Source for BtSocket { ... } // for async IO with mio
 ```
 
 [Click here](examples/example.rs) for full example.

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,9 +1,7 @@
 use bluetooth_serial_port::{BtProtocol, BtSocket};
-use mio::{Poll, PollOpt, Ready, Token};
-use std::{
-    io::{Read, Write},
-    time,
-};
+use std::io::{Read, Write};
+use std::time;
+use mio::{Poll, Token, Interest};
 
 fn main() {
     // scan for devices
@@ -37,12 +35,6 @@ fn main() {
 
     // BtSocket also implements `mio::Evented` for async IO
     let poll = Poll::new().unwrap();
-    poll.register(
-        &socket,
-        Token(0),
-        Ready::readable() | Ready::writable(),
-        PollOpt::edge() | PollOpt::oneshot(),
-    )
-    .unwrap();
+    poll.registry().register(&mut socket, Token(0), Interest::READABLE | Interest::WRITABLE).unwrap();
     // loop { ... poll events and wait for socket to be readable/writable ... }
 }

--- a/src/bluetooth.rs
+++ b/src/bluetooth.rs
@@ -123,7 +123,7 @@ impl Write for BtSocket {
 #[allow(missing_debug_implementations)] // `&mio::Evented` doesn't do `Debug`
 pub enum BtAsync<'a> {
     /// Caller needs to wait for the given `Evented` object to reach the given `Ready` state
-    WaitFor(&'a mio::Evented, mio::Ready),
+    WaitFor(&'a dyn mio::Evented, mio::Ready),
 
     /// Asynchronous transaction has completed
     Done,
@@ -160,7 +160,7 @@ pub enum BtError {
     Unknown,
 
     /// On Unix platforms: the error code and an explanation for this error code.
-    Errno(u32, String),
+    Errno(i32, String),
 
     /// This error only has a description.
     Desc(String),
@@ -171,18 +171,7 @@ pub enum BtError {
 
 impl std::fmt::Display for BtError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:}", std::error::Error::description(self))
-    }
-}
-
-impl std::error::Error for BtError {
-    fn description(&self) -> &str {
-        match self {
-            BtError::Unknown => "Unknown Bluetooth Error",
-            BtError::Errno(_, ref message) => message.as_str(),
-            BtError::Desc(ref message) => message.as_str(),
-            BtError::IoError(ref err) => err.description(),
-        }
+        write!(f, "{:}", self)
     }
 }
 
@@ -309,7 +298,7 @@ mod tests {
     use super::*;
     use std::str::FromStr;
 
-    #[test()]
+    #[test]
     fn btaddr_from_string() {
         match BtAddr::from_str("00:00:00:00:00:00") {
             Ok(addr) => assert_eq!(addr, BtAddr([0u8; 6])),
@@ -331,13 +320,13 @@ mod tests {
         }
     }
 
-    #[test()]
+    #[test]
     fn btaddr_to_string() {
         assert_eq!(BtAddr::any().to_string(), "00:00:00:00:00:00");
         assert_eq!(BtAddr([1, 2, 3, 4, 5, 6]).to_string(), "01:02:03:04:05:06");
     }
 
-    #[test()]
+    #[test]
     fn btaddr_roundtrips_to_from_str() {
         let addr = BtAddr([0, 22, 4, 1, 33, 192]);
         let addr_string = "00:ff:ee:ee:dd:12";
@@ -349,13 +338,13 @@ mod tests {
     }
 
     #[cfg(not(feature = "test_without_hardware"))]
-    #[test()]
+    #[test]
     fn creates_rfcomm_socket() {
         BtSocket::new(BtProtocol::RFCOMM).unwrap();
     }
 
     #[cfg(not(feature = "test_without_hardware"))]
-    #[test()]
+    #[test]
     fn scans_devices() {
         scan_devices(time::Duration::from_secs(20)).unwrap();
     }

--- a/src/linux/sdp.rs
+++ b/src/linux/sdp.rs
@@ -388,7 +388,7 @@ impl QueryRFCOMMChannel {
                 assert!(!self.session.is_null());
                 unsafe { (*self.session).sock }
             }};
-        };
+        }
 
         match self.state {
             QueryRFCOMMChannelState::New => {

--- a/src/linux/socket.rs
+++ b/src/linux/socket.rs
@@ -2,7 +2,6 @@ use super::sdp::{QueryRFCOMMChannel, QueryRFCOMMChannelStatus};
 use crate::bluetooth::{BtAddr, BtAsync, BtError, BtProtocol};
 use mio::{unix::EventedFd, Poll, Ready};
 use std::{
-    error::Error,
     io::{Read, Write},
     mem,
     os::unix::{
@@ -12,10 +11,10 @@ use std::{
 };
 
 pub fn create_error_from_errno(message: &str, errno: i32) -> BtError {
-    let nix_error = nix::Error::from_errno(nix::errno::from_i32(errno));
+    let nix_error = nix::errno::from_i32(errno);
     BtError::Errno(
-        errno as u32,
-        format!("{:}: {:}", message, nix_error.description()),
+        errno,
+        format!("{:}: {:}", message, nix_error),
     )
 }
 pub fn create_error_from_last(message: &str) -> BtError {
@@ -94,10 +93,7 @@ impl BtSocket {
 
 impl From<nix::Error> for BtError {
     fn from(e: nix::Error) -> BtError {
-        BtError::Errno(
-            e.as_errno().map(|x| x as u32).unwrap_or(0),
-            e.description().to_string(),
-        )
+        BtError::Errno(e as i32, e.to_string())
     }
 }
 


### PR DESCRIPTION
Hey,

First of all thanks a lot for putting this together!
I've been using the lib for embedded experiments and I would like to make it possible to use with recent version of `tokio`.

I've created this change and did a few tests (which are far from exhaustive), but it seems working (at least in my setup).
So could you please kindly have a look and maybe consider updating the crate?

Please let me know if anything needs fixing. One notable change in `mio` is deprecation of `PollOpt`, callers now are required to register/deregister manually in case they want to mimic `oneshot` functionality (reference https://tokio.rs/blog/2019-12-mio-v0.7-alpha.1)

I've looked into he main loop in `connect`, and didn't find additional changes necessary there, but I don't have in-depth understanding of the lib so maybe you could correct me if I'm wrong.

Cheers!